### PR TITLE
xiaomi-ugg: Add Xiaomi Redmi Note 5A (Redmi Y1) support

### DIFF
--- a/dts/msm8940-xiaomi-ugg.dts
+++ b/dts/msm8940-xiaomi-ugg.dts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8952.dtsi"
+
+/ {
+	// This is used by the bootloader to find the correct DTB 
+	qcom,msm-id = <313 0x0>;
+	qcom,board-id = <0x08 0>;
+
+	model = "Xiaomi Redmi Note 5A (ugg)";
+	compatible = "xiaomi,ugg", "qcom,msm8940", "lk2nd,device";
+
+	// Bootloader won't continue if it can't delete some nodes from below
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x0 0x0 0xffffffff>;
+
+	};
+};

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -13,7 +13,8 @@ DTBS += \
 endif
 ifeq ($(PROJECT), msm8952-secondary)
 DTBS += \
-	$(LOCAL_DIR)/msm8940-xiaomi-santoni.dtb
+	$(LOCAL_DIR)/msm8940-xiaomi-santoni.dtb \
+	$(LOCAL_DIR)/msm8940-xiaomi-ugg.dtb
 endif
 ifeq ($(PROJECT), msm8917-secondary)
 DTBS += \


### PR DESCRIPTION
Add support with Xiaomi ugg (not ugglite) for someone in China need join Mainline kernel party.

cc: @Tony0812-dev

![image](https://user-images.githubusercontent.com/64141442/98456331-542e8a00-21b7-11eb-9983-f589cda76a2f.png)
