### PR TITLE
dts: Add Asus Zenfone Max M1 (X00P)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and then loaded by lk2nd.
 ## Supported SoCs
 - MSM8916
 - MSM8953 (SDM450,SDM625)
-- MSM8952 (MSM8940)
+- MSM8952 (MSM8937,MSM8940)
 
 ### Supported devices
 - Motorola Moto G4 Play (harpia)
@@ -29,6 +29,7 @@ and then loaded by lk2nd.
 - Samsung Galaxy A6+ (2018) - SM-A605FN
 - Xiaomi Redmi 4X - santoni
 - Xiaomi Redmi Note 4X Snapdragon - mido
+- Asus Zenfone Max M1 - X00P
 
 ## Installation
 1. Download `lk2nd.img` (available in [Releases](https://github.com/msm8916-mainline/lk2nd/releases)(MSM8916))

--- a/dts/msm8937-asus-x00p.dts
+++ b/dts/msm8937-asus-x00p.dts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8937.dtsi"
+
+/ {
+	// This is used by the bootloader to find the correct DTB 
+	qcom,msm-id = <0x126 0x00>;
+	qcom,board-id= <0x08 0x00>;
+
+	model = "Asus Zenfone Max M1(X00P)";
+	compatible = "asus,x00p", "qcom,msm8937-mtp", "qcom,msm8937", "qcom,mtp", "lk2nd,device";
+
+	// Bootloader won't continue if it can't delete some nodes from below
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x0 0x0 0xffffffff>;
+
+	};
+
+};

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -17,5 +17,6 @@ DTBS += \
 endif
 ifeq ($(PROJECT), msm8952-secondary)
 DTBS += \
+	$(LOCAL_DIR)/msm8937-asus-x00p.dtb \
 	$(LOCAL_DIR)/msm8940-xiaomi-santoni.dtb
 endif


### PR DESCRIPTION
Device is msm8937, but is compatible with msm8952 and similar chipsets.
