### PR TITLE
fixup! xiaomi-daisy: Add panel selection and bootloader matching

### DIFF
--- a/dts/msm8953-xiaomi-daisy.dts
+++ b/dts/msm8953-xiaomi-daisy.dts
@@ -16,7 +16,7 @@
 	panel {
 		compatible = "xiaomi,daisy-panel";
 		qcom,mdss_dsi_ili7807_fhd_video {
-			compatible = "mdss,ili7807-fhd";
+			compatible = "mdss,ili7807-fhdplus";
 		};
 		qcom,mdss_dsi_hx8399c_fhdplus_video {
 			compatible = "himax,hx8399c-fhdplus";


### PR DESCRIPTION
The panel selection compatible for the ili7808 panel was wrong. This should go with a new tag (i.e. 0.3.1) and then bump the pmos package version too.