### PR TITLE
Detect libfdt with different filenames in dtbTool

### DIFF
--- a/scripts/dtbTool
+++ b/scripts/dtbTool
@@ -142,9 +142,18 @@ boot_device_ids = { 'emmc_sdc1' : 2, 'ufs' : 4 }
 boot_device_ids_mdm = { 'emmc_sdc1' : 3 }
 panel_ids = { 'hd' : 0, '720p' : 1, 'qHD' : 2, 'fWVGA' : 3 }
 
-try:
-	libfdt = ctypes.CDLL('libfdt.so')
-except OSError:
+# Load libfdt using a number of possible filenames used by distributions
+libfdt_fnames = ['libfdt.so', 'libfdt.so.1']
+libfdt = None
+
+for fname in libfdt_fnames:
+    try:
+        libfdt = ctypes.CDLL(fname)
+        break
+    except OSError:
+        continue
+
+if not libfdt:
 	sys.exit("libfdt is missing, please install it")
 
 prototype = ctypes.CFUNCTYPE(ctypes.c_char_p, ctypes.c_void_p, ctypes.c_char_p)


### PR DESCRIPTION
On Fedora 35 (and possibly other distros) libfdt is distributed under filename different than "libfdt.so", specifically "libfdt-1.6.1.so" with a symlink to it at "libfdt.so.1". This pull request enables the dtbTool script to locate libfdt in both cases and can easily be extended if necessary by adding more entries in libfdt_fnames.