### PR TITLE
don't boot from ext2fs boot.img if user requested recovery

### DIFF
--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -5316,13 +5316,17 @@ normal_boot:
 	{
 		if (target_is_emmc_boot())
 		{
-			/* Try to boot from first fs we can find */
-			ssize_t loaded_file = fsboot_boot_first(target_get_scratch_address(), target_get_max_flash_size());
+			if(! boot_into_recovery) {
+				/* Try to boot from first fs we can find */
 
-			if (loaded_file > 0)
-				cmd_boot(NULL, target_get_scratch_address(), target_get_max_flash_size());
+				ssize_t loaded_file = fsboot_boot_first(target_get_scratch_address(), target_get_max_flash_size());
 
-			dprintf(CRITICAL, "Unable to load boot.img from ext2. Continuing legacy boot\n");
+				if (loaded_file > 0) {
+					dprintf(INFO, "Booting boot.img from ext2 %x %x\n", target_get_scratch_address(), target_get_max_flash_size());
+					cmd_boot(NULL, target_get_scratch_address(), loaded_file);
+					goto fastboot;
+				}
+			}
 
 			if(emmc_recovery_init())
 				dprintf(ALWAYS,"error in emmc_recovery_init\n");


### PR DESCRIPTION
# Problem

When there is an ext2 filesystem on `system` or `userdata` partition containing a valid `boot.img`,  holding Vol Up to boot recovery has no effect

# Solution

When booting a `boot.img` from an ext2 filesystem, first check  `boot_into_recovery` is not set.  

## Other change that I made at the same time

We pass the actual image size as the second param to `cmd_boot`, instead of target_get_max_flash_size(). I don't think it makes an actual difference but it more closely matches the other call to `cmd_boot`

