### PR TITLE
RFC: fix DMA to unaligned buffers

### DIFF
--- a/lib/fs/ext2/io.c
+++ b/lib/fs/ext2/io.c
@@ -229,22 +229,17 @@ ssize_t ext2_read_inode(ext2_t *ext2, struct ext2_inode *inode, void *_buf, off_
 	while (len >= EXT2_BLOCK_SIZE(ext2->sb)) {
 		/* calculate the block and read it */
 		blocknum_t phys_block = file_block_to_fs_block(ext2, inode, file_block);
-        blocknum_t count_cont_blks = 1;
-        blocknum_t max_blocks = len / EXT2_BLOCK_SIZE(ext2->sb);
 		if (phys_block == 0) {
 			memset(buf, 0, EXT2_BLOCK_SIZE(ext2->sb));
 		} else {
-            while (count_cont_blks < max_blocks && file_block_to_fs_block(ext2, inode, file_block + count_cont_blks) == phys_block + count_cont_blks) {
-                count_cont_blks++;
-            }
-            bio_read(ext2->dev, buf, EXT2_BLOCK_SIZE(ext2->sb) * phys_block, EXT2_BLOCK_SIZE(ext2->sb) * count_cont_blks);
+			ext2_read_block(ext2, buf, phys_block);
 		}
 
 		/* increment our stuff */
-        file_block += count_cont_blks;
-        len -= EXT2_BLOCK_SIZE(ext2->sb) * count_cont_blks;
-        bytes_read += EXT2_BLOCK_SIZE(ext2->sb) * count_cont_blks;
-        buf += EXT2_BLOCK_SIZE(ext2->sb) * count_cont_blks;
+		file_block++;
+		len -= EXT2_BLOCK_SIZE(ext2->sb);
+		bytes_read += EXT2_BLOCK_SIZE(ext2->sb);
+		buf += EXT2_BLOCK_SIZE(ext2->sb);
 	}
 
 	/* handle partial last block */

--- a/platform/msm_shared/sdhci.c
+++ b/platform/msm_shared/sdhci.c
@@ -768,7 +768,7 @@ uint32_t sdhci_send_command(struct sdhci_host *host, struct mmc_command *cmd)
 	 * may not be aligned to cache boundary due to
 	 * certain image formats like sparse image.
 	 */
-	if (cmd->trans_mode == SDHCI_READ_MODE)
+	if (cmd->trans_mode & (SDHCI_READ_MODE | SDHCI_MMC_READ))
 		ASSERT(IS_CACHE_LINE_ALIGNED(cmd->data.data_ptr));
 
 	do {


### PR DESCRIPTION
# what it does

I'm feeling my way around here and not an expert. But I think the mmc device expects to read into a buffer that's aligned to a cache line, and there are some places in the e2fs code that don't. This PR

1. corrects the ASSERT in sdhci.c to check for both kinds of read transfer (SDHCI_READ_MODE and SDHCI_MMC_READ)
2. changes bcache to provide aligned buffers for any code path that goes through `ext2_read_block`
3. reverts a previous optimisation that was calling bio_read directly instead of ext2_read_block and didn't guarantee alignment
4. changes a couple of places in the ext2 code that call bio_read directly to make sure their buffers are aligned

As I said, not an expert. If I leave the ASSERT how it was and do only point (2) it's sufficient to boot my image, which does slightly make me wonder if the problem lies somewhere else completely. I note a previous attempt at changing the assertion was subsequently reverted (,https://github.com/msm8953-mainline/lk2nd/commit/4abeb266b8f7a51071327a1a88d6b5624a470199) but the git history is not forthcoming on why that happened.


# backstory/thought process

When using the support for loading boot.img from ext2fs, I was observing corruption in the image that caused the kernel to fail to unpack the  initrd (`XZ-compressed data is corrupt`)

The image itself was OK: I can boot it just fine with `fastboot boot boot.img`, unpack it with binwalk, etc.

By setting DEBUG_HEAP and inserting debugging code I narrowed it down to an attempt to read into the third of the four buffers defined in bcache.c. bio_read _appeared_ to be copying only 4060 out of 4096 bytes (https://gist.github.com/telent/cfb12a4ec4545a5370e841166c3c2cc8) but was still returning 4096. But if I performed the same read into a statically allocated buffer I got the full 4096 bytes correctly. 

Then I saw https://github.com/msm8916-mainline/lk2nd/commit/9d51909dc857cb3daf74a12173f754b7e9791f56 while looking for inspiration and took a leap of faith.
