### PR TITLE
Add note that Motorola Moto G5 Plus (potter) can also be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ and then loaded by lk2nd.
 
 ### Supported devices
 - Motorola Moto G4 Play (harpia)
+- Motorola Moto G5 Plus (potter)
 - Samsung Galaxy A3 (2015) - SM-A300FU
 - Samsung Galaxy A5 (2015) - SM-A500FU
 - Samsung Galaxy J5 (2016) - SM-J510FN


### PR DESCRIPTION
Normally people know that the aforementioned can be used by being redirected here; but for the people who stumble across this, it would be helpful to let them know that it is supported.