### PR TITLE
Add SM-T590 (gta2xlwifi) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ and then loaded by lk2nd.
 - Xiaomi Mi A2 Lite - daisy
 - Xiaomi Mi A1 - tissot
 - XIaomi Mi A2 Lite - daisy
+- Samsung Galaxy Tab A2 XL WiFi (2018) - SM-T590
 
 ## Installation
 1. Download `lk2nd.img` (as of now there's no build available so you'll need to build it yourself.)

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -15,7 +15,8 @@ DTBS += \
 	$(LOCAL_DIR)/msm8953-xiaomi-vince.dtb \
 	$(LOCAL_DIR)/msm8953-meizu-m1721.dtb \
 	$(LOCAL_DIR)/msm8953-motorola-potter.dtb \
-	$(LOCAL_DIR)/msm8953-tenor-holland.dtb
+	$(LOCAL_DIR)/msm8953-tenor-holland.dtb \
+	$(LOCAL_DIR)/sdm450-samsung-r05.dtb
 endif
 ifeq ($(PROJECT), msm8952-secondary)
 DTBS += \

--- a/dts/sdm450-samsung-r05.dts
+++ b/dts/sdm450-samsung-r05.dts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8953.dtsi"
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+	qcom,msm-id = <351 0x0>;
+	qcom,board-id = <8 5>;
+	
+	gta2xlwifi-generic {
+		model = "Samsung Tab A2 XL WIFI Rev05";
+		compatible = "samsung,gta2xlwifi-eur", "qcom,sdm450", "qcom,msm8953", "lk2nd,device";
+		lk2nd,match-bootloader = "T590*";
+		lk2nd,pstore = <0x86100000 0x100000>;
+	};
+	
+	// Bootloader won't continue if it can't delete some nodes from below
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x0 0x0 0xffffffff>;
+
+		qcom,memshare {
+			qcom,client_4 {
+				qcom,peripheral-size = <0x6000000>;
+			};
+		};
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		sec_debug_region@0 {
+			compatible = "removed-dma-pool";
+			no-map;
+			reg = <0x0 0x85000000 0x0 0x800000>;
+		};
+
+		sec_debug_low_region@0 {
+			compatible = "removed-dma-pool";
+			no-map;
+			reg = <0x0 0x85000000 0x0 0x400000>;
+		};
+
+		lk_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			no-map;
+			reg = <0x0 0x8f600000 0x0 0x300000>;
+			label = "lk_mem";
+		};
+
+		modem_shared_mem_region@0x93000000 {
+			reg = <0x0 0x93000000 0x0 0x6000000>;
+		};
+
+	};
+};


### PR DESCRIPTION
Add support for the Samsung Galaxy Tab A2 XL WiFI (2018) Rev05.