### PR TITLE
dts: Add Samsung gts210vewifi Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The real Android boot image is placed into the boot partition with 1 MB offset,
 and then loaded by lk2nd.
 
 ## Supported SoCs
-- MSM8952 (MSM8940)
+- MSM8952 (MSM8940,APQ8076)
 - MSM8953 (SDM450,SDM625,SDM626)
 - SDM632
 
@@ -33,6 +33,7 @@ and then loaded by lk2nd.
 - Xiaomi Mi A2 Lite - daisy
 - Xiaomi Mi A1 - tissot
 - XIaomi Mi A2 Lite - daisy
+- Samsung Galaxy Tab S2 9.7 Wifi - SM-T813 (quirky - see comment in dts/apq8076-samsung-gts210vewifi.dts)
 
 ## Installation
 1. Download `lk2nd.img` (as of now there's no build available so you'll need to build it yourself.)

--- a/dts/apq8076-samsung-gts210vewifi.dts
+++ b/dts/apq8076-samsung-gts210vewifi.dts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8952.dtsi"
+
+/ {
+	// This is used by the bootloader to find the correct DTB
+	qcom,msm-id = <0x115 0x01>;
+	qcom,board-id = <0x08 0x04>;
+	/*
+	* To build for samsung-gts210vewifi, comment out all dtbs and add
+	* $(LOCAL_DIR)/apq8076-samsung-gts210vewifi.dtb to rules.mk in this directory.
+	* samsung-gts210vewifi does not work with all dtbs enabled.
+	 */
+	gts210vewifi{
+
+		model = "Samsung GTS210VEWIFI EUR OPEN PROJECT Rev04";
+		compatible = "samsung,gts210vewifi",
+		             "qcom,apq8076",
+		             "qcom,msm8952",
+		             "lk2nd,device";
+		// lk2nd,match-cmdline = "* mdss_mdp.panel=1: dsi: 0: ss_dsi_panel_ANA38401_AMS968HH01_QXGA: 1: ss_dsi_panel_ANA38";
+		lk2nd,match-bootloader = "T813*";
+
+	};
+
+	// Bootloader won't continue if it can't delete some nodes from below
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x0 0x0 0xffffffff>;
+
+		qcom,memshare {
+			compatible = "qcom,memshare";
+
+			qcom,client_1 {
+				compatible = "qcom,memshare-peripheral";
+				qcom,peripheral-size = <0x200000>;
+				qcom,client-id = <0x00>;
+				qcom,allocate-boot-time;
+				label = "modem";
+			};
+
+			qcom,client_2 {
+				compatible = "qcom,memshare-peripheral";
+				qcom,peripheral-size = <0x300000>;
+				qcom,client-id = <0x02>;
+				label = "modem";
+			};
+
+			qcom,client_3 {
+				compatible = "qcom,memshare-peripheral";
+				qcom,peripheral-size = <0x00>;
+				qcom,client-id = <0x01>;
+				label = "modem";
+			};
+		};
+	};
+
+	reserved-memory {
+
+		lk_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			reg = <0x00 0x8f600000 0x00 0x300000>;
+			label = "lk_mem";
+		};
+
+		secdbg_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			reg = <0x00 0xa0000000 0x00 0x800000>;
+			label = "secdbg_mem";
+		};
+
+		klog_region@0 {
+			linux,reserve-contiguous-region;
+			linux,reserve-region;
+			linux,remove-completely;
+			reg = <0x00 0xa01ff000 0x00 0x201000>;
+			label = "klog_mem";
+		};
+	};
+};

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -20,7 +20,8 @@ endif
 ifeq ($(PROJECT), msm8952-secondary)
 DTBS += \
 	$(LOCAL_DIR)/msm8940-xiaomi-santoni.dtb \
-	$(LOCAL_DIR)/msm8940-xiaomi-ugg.dtb
+	$(LOCAL_DIR)/msm8940-xiaomi-ugg.dtb \
+	$(LOCAL_DIR)/apq8076-samsung-gts210vewifi.dtb
 endif
 ifeq ($(PROJECT), msm8917-secondary)
 DTBS += \


### PR DESCRIPTION
Although it seems that logs and getvar can be obtained, there is no menu to display.

![PXL_20221217_231044845](https://user-images.githubusercontent.com/24770600/208249894-6228dd08-5071-414f-a01b-a65cade5041c.jpg)

logs:
[lk_log.txt](https://github.com/msm8953-mainline/lk2nd/files/10252083/lk_log.txt)
[lk_vars.txt](https://github.com/msm8953-mainline/lk2nd/files/10252084/lk_vars.txt)
