### PR TITLE
[WIP] [need help] Add Xiaomi oxygen (Mi Max 2) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and then loaded by lk2nd.
 - Motorola Moto G7 Power - ocean
 - Xiaomi Mi A2 Lite - daisy
 - Xiaomi Mi A1 - tissot
-- XIaomi Mi A2 Lite - daisy
+- XIaomi Mi Max 2 - oxygen
 
 ## Installation
 1. Download `lk2nd.img` (as of now there's no build available so you'll need to build it yourself.)

--- a/dts/msm8953-xiaomi-oxygen.dts
+++ b/dts/msm8953-xiaomi-oxygen.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8953.dtsi"
+
+/ {
+	qcom,msm-id = <293 0x0>;
+	qcom,board-id= <26 0>;
+
+	model = "Xiaomi Mi Max 2";
+	compatible = "xiaomi,oxygen", "qcom,msm8953", "lk2nd,device";
+};

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -12,6 +12,7 @@ DTBS += \
 	$(LOCAL_DIR)/sdm632-fairphone-fp3.dtb \
 	$(LOCAL_DIR)/sdm632-motorola-ocean.dtb \
 	$(LOCAL_DIR)/msm8953-xiaomi-daisy.dtb \
+	$(LOCAL_DIR)/msm8953-xiaomi-oxygen.dtb \
 	$(LOCAL_DIR)/msm8953-xiaomi-vince.dtb \
 	$(LOCAL_DIR)/msm8953-meizu-m1721.dtb \
 	$(LOCAL_DIR)/msm8953-motorola-potter.dtb \


### PR DESCRIPTION
I have added basic DTB that boots but I believe  I'm unable to boot into lk2nd fastboot mode because I see the little penguin splash screen and it goes to black after that.

can any one help me here? 

I have compiled it with two gcc versions in case there is incompatibility with gcc version :
    * arm-none-eabi-gcc-cs-1:12.2.0-1.fc37.x86_64
    * gcc-arm-10.3-2021.07-x86_64-arm-none-eabi
  
I have tried different key combinations also Volume Down/Up and ..