### PR TITLE
Add support for Redmi 6 Pro (xiaomi-sakura)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ and then loaded by lk2nd.
 - Xiaomi Redmi 4 Prime - markw
 - Xiaomi Redmi Note 5 / 5 Plus Snapdragon - vince
 - Xiaomi Redmi S2 / Y2 - ysl
+- Xiaomi Redmi 6 Pro - sakura
 - Meizu M6 Note - m1721
 - Motorola Moto G7 Power - ocean
 - Xiaomi Mi A2 Lite - daisy
 - Xiaomi Mi A1 - tissot
-- XIaomi Mi A2 Lite - daisy
 - Samsung Galaxy Tab A2 XL WiFi (2018) - SM-T590
 
 ## Installation

--- a/dts/msm8953-xiaomi-common.dts
+++ b/dts/msm8953-xiaomi-common.dts
@@ -29,7 +29,28 @@
 			};
 		};
 	};
-	
+
+	sakura {
+		/* Xiaomi Redmi 6 Pro (sakura) and Xiaomi Mi A2 Lite (daisy) are software compatible */
+		model = "Xiaomi Redmi 6 Pro";
+		compatible = "xiaomi,sakura", "qcom,msm8953", "lk2nd,device";
+		lk2nd,match-bootloader = "*DAISY*";
+		lk2nd,pstore = <0x9ff00000 0x100000>;
+
+		panel {
+			compatible = "xiaomi,daisy-panel";
+			qcom,mdss_dsi_ili7807_fhdplus_video {
+				compatible = "mdss,ili7807-fhdplus";
+			};
+			qcom,mdss_dsi_hx8399c_fhdplus_video {
+				compatible = "himax,hx8399c-fhdplus";
+			};
+			qcom,mdss_dsi_otm1911_fhdplus_video {
+				compatible = "mdss,otm1911-fhdplus";
+			};
+		};
+	};
+
 	mido {
 		model = "Xiaomi Redmi Note 4X Snapdragon (mido)";
 		compatible = "xiaomi,mido", "qcom,msm8953", "lk2nd,device";


### PR DESCRIPTION
It works fine for me I can go in the bootloader menu and i can use MI A2 Lite variant of PMOS also.