### PR TITLE
Delay arch_disable_mmu()

### DIFF
--- a/app/aboot/aboot.c
+++ b/app/aboot/aboot.c
@@ -1325,17 +1325,19 @@ void boot_linux(void *kernel, unsigned *tags,
 
 	arch_disable_cache(UCACHE);
 
-#if ARM_WITH_MMU
-	arch_disable_mmu();
-#endif
 	bs_set_timestamp(BS_KERNEL_ENTRY);
 
 	if (IS_ARM64(kptr))
 		/* Jump to a 64bit kernel */
 		scm_elexec_call((paddr_t)kernel, tags_phys);
-	else
+	else {
+		#if ARM_WITH_MMU
+		arch_disable_mmu();
+		#endif
+
 		/* Jump to a 32bit kernel */
 		entry(0, machtype, (unsigned*)tags_phys);
+	}
 }
 
 /* Function to check if the memory address range falls within the aboot

--- a/platform/msm_shared/scm.c
+++ b/platform/msm_shared/scm.c
@@ -1067,6 +1067,9 @@ void scm_elexec_call(paddr_t kernel_entry, paddr_t dtb_offset)
 	/* Response Buffer = Null as no response expected */
 	dprintf(INFO, "Jumping to kernel via monitor\n");
 	pmic_reset_configure(0x1);
+	#if ARM_WITH_MMU
+	arch_disable_mmu();
+	#endif
 
 	if (!is_scm_armv8_support())
 	{


### PR DESCRIPTION
On gcc versions after 11.2.0, when using -O2 the compiler inlines pm8xxx_reg_write()
function into the others that use it. However, when it does so, on the
assembly `cmd` ends up unaligned. This is fine if MMU is enabled, but
when executing pmic_reset_configure(), inside scm_elexec_call(), MMU is
disabled. This causes a data abort, which causes lk to try and reboot
into DLOAD mode, only to hit the exact same bug on
pm8x41_clear_pmic_watchdog().

Fix this by keeping MMU enabled until almost just before kernel is about
to boot. This way we also avoid potentially hitting the same bug on
another function in the future.
