### PR TITLE
Daisy touchscreen compatible

### DIFF
--- a/app/aboot/lk2nd-device.c
+++ b/app/aboot/lk2nd-device.c
@@ -276,8 +276,8 @@ static const char *fdt_getprop_str(const void *fdt, int offset, const char *prop
 static void lk2nd_parse_panels(const void *fdt, int offset)
 {
 	struct lk2nd_panel *panel = &lk2nd_dev.panel;
-	const char *old, *new;
-	int old_len, new_len;
+	const char *old, *new, *ts;
+	int old_len, new_len, ts_len;
 
 	offset = fdt_subnode_offset(fdt, offset, "panel");
 	if (offset < 0)
@@ -306,6 +306,16 @@ static void lk2nd_parse_panels(const void *fdt, int offset)
 
 	strlcpy((char*) panel->compatible, new, new_len);
 	strlcpy((char*) panel->old_compatible, old, old_len);
+
+	ts = fdt_getprop_str(fdt, offset, "touchscreen-compatible", &ts_len);
+	if (!ts || ts_len < 1)
+		return;
+
+	panel->ts_compatible = malloc(ts_len);
+	ASSERT(panel->ts_compatible);
+	strlcpy((char*) panel->ts_compatible, ts, ts_len + 1);
+
+	dprintf(INFO, "Found touchscreen-compatible: %s\n", panel->ts_compatible);
 }
 
 static void lk2nd_parse_device_node(const void *fdt)
@@ -433,6 +443,17 @@ static void lk2nd_update_panel_compatible(void *fdt)
 	ret = fdt_setprop(fdt, offset, "compatible", panel->compatible, panel->compatible_size);
 	if (ret)
 		dprintf(CRITICAL, "Failed to update panel compatible: %d\n", ret);
+
+	/* Enable associated touchscreen if any */
+	if (panel->ts_compatible) {
+		offset = fdt_node_offset_by_compatible(fdt, -1, panel->ts_compatible);
+		if (offset < 0)
+			return;
+
+		ret = fdt_nop_property(fdt, offset, "status");
+		if (ret)
+			dprintf(CRITICAL, "Failed to NOP touchscreen status: %d\n", ret);
+	}
 }
 
 void lk2nd_update_device_tree(void *fdt, const char *cmdline)

--- a/app/aboot/lk2nd-device.h
+++ b/app/aboot/lk2nd-device.h
@@ -10,6 +10,7 @@ struct lk2nd_panel {
 	const char *old_compatible;
 	const char *compatible;
 	int compatible_size;
+	const char *ts_compatible;
 };
 
 struct lk2nd_device {

--- a/dts/msm8953-xiaomi-common.dts
+++ b/dts/msm8953-xiaomi-common.dts
@@ -41,12 +41,15 @@
 			compatible = "xiaomi,daisy-panel";
 			qcom,mdss_dsi_ili7807_fhdplus_video {
 				compatible = "mdss,ili7807-fhdplus";
+				touchscreen-compatible = "goodix,gt917d";
 			};
 			qcom,mdss_dsi_hx8399c_fhdplus_video {
 				compatible = "himax,hx8399c-fhdplus";
+				touchscreen-compatible = "edt,edt-ft5406";
 			};
 			qcom,mdss_dsi_otm1911_fhdplus_video {
 				compatible = "mdss,otm1911-fhdplus";
+				touchscreen-compatible = "goodix,gt917d";
 			};
 		};
 	};

--- a/dts/msm8953-xiaomi-daisy.dts
+++ b/dts/msm8953-xiaomi-daisy.dts
@@ -17,12 +17,15 @@
 		compatible = "xiaomi,daisy-panel";
 		qcom,mdss_dsi_ili7807_fhdplus_video {
 			compatible = "mdss,ili7807-fhdplus";
+			touchscreen-compatible = "goodix,gt917d";
 		};
 		qcom,mdss_dsi_hx8399c_fhdplus_video {
 			compatible = "himax,hx8399c-fhdplus";
+			touchscreen-compatible = "edt,edt-ft5406";
 		};
 		qcom,mdss_dsi_otm1911_fhdplus_video {
 			compatible = "mdss,otm1911-fhdplus";
+			touchscreen-compatible = "goodix,gt917d";
 		};
 	};
 


### PR DESCRIPTION
Mostly copied from https://github.com/msm8916-mainline/lk2nd/pull/217, but for msm8953 and Xiaomi Daisy.