### PR TITLE
aboot: Fix A/B slot success logic

### DIFF
--- a/app/aboot/lk2nd-device.c
+++ b/app/aboot/lk2nd-device.c
@@ -401,10 +401,10 @@ static void lk2nd_handle_multislot(void)
 
 	if (strcmp(lk2nd_dev.slot_suffix, "_a") == 0) {
 		dprintf(INFO, "Marking Slot A as successful.\n");
-		partition_reset_retry_count(SLOT_A);
+		partition_set_successful(SLOT_A);
 	} else if (strcmp(lk2nd_dev.slot_suffix, "_b") == 0) {
 		dprintf(INFO, "Marking Slot B as successful.\n");
-		partition_reset_retry_count(SLOT_B);
+		partition_set_successful(SLOT_B);
 	} else {
 		dprintf(CRITICAL, "ERROR: Couldn't determine slot suffix of %s\n", lk2nd_dev.slot_suffix);
 	}

--- a/platform/msm_shared/ab_partition_parser.c
+++ b/platform/msm_shared/ab_partition_parser.c
@@ -144,15 +144,19 @@ partition_activate_slot(int slot)
 	return;
 }
 
-void partition_reset_retry_count(int slot)
+void partition_set_successful(int slot)
 {
 	struct partition_entry *partition_entries =
 			partition_get_partition_entries();
 	int slt_index = boot_slot_index[slot];
 
-	/* Set Max retry count and priority value */
-	partition_entries[slt_index].attribute_flag |= (PART_ATT_PRIORITY_VAL |
-							PART_ATT_MAX_RETRY_COUNT_VAL);
+	/* Set Success bit */
+	SET_BIT(partition_entries[slt_index].attribute_flag, PART_ATT_SUCCESS_BIT);
+
+	attributes_updated = true;
+
+	/* Make attributes persistant */
+	partition_mark_active_slot(active_slot);
 
 	return;
 }

--- a/platform/msm_shared/include/ab_partition_parser.h
+++ b/platform/msm_shared/include/ab_partition_parser.h
@@ -72,7 +72,7 @@ void partition_fill_slot_meta();	/* Fill slot meta infomation */
 void partition_switch_slots();		/* Switching slots */
 void partition_deactivate_slot(int slot); /* Mark slot unbootable and reset other attributes*/
 void partition_activate_slot(int slot);	 /* Mark slot bootable and set other attributes*/
-void partition_reset_retry_count(int slot);	/* Reset retry count of slot */
+void partition_set_successful(int slot);	/* Mark slot successful */
 int partition_find_boot_slot();		/* Find bootable partition */
 int partition_find_active_slot();	/* Find current active partition*/
 int partition_fill_partition_meta();	/* Fill partition slot info meta*/


### PR DESCRIPTION
It is enough just to set the success flag for the current slot instead of touching the retry counter ourselves. The primary bootloader should do that for us if it sees the success flag.

Also it appears we never actually wrote the flags to disk in the original commit, so let's do that with attributes_updated variable and the partition_mark_active_slot function.