### PR TITLE
Add support for Xiaomi Redmi 7A (pine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ and then loaded by lk2nd.
 - Xiaomi Redmi S2 / Y2 - ysl
 - Xiaomi Redmi 6 Pro - sakura
 - Xiaomi Redmi 7 - onclite
+- Xiaomi Redmi 7A - pine
 - Meizu M6 Note - m1721
 - Motorola Moto G7 Power - ocean
 - Xiaomi Mi A2 Lite - daisy

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -25,7 +25,8 @@ endif
 ifeq ($(PROJECT), msm8952-secondary)
 DTBS += \
 	$(LOCAL_DIR)/msm8940-xiaomi-santoni.dtb \
-	$(LOCAL_DIR)/msm8940-xiaomi-ugg.dtb
+	$(LOCAL_DIR)/msm8940-xiaomi-ugg.dtb \
+	$(LOCAL_DIR)/sdm439-xiaomi-pine.dtb
 endif
 ifeq ($(PROJECT), msm8917-secondary)
 DTBS += \

--- a/dts/sdm439-xiaomi-pine.dts
+++ b/dts/sdm439-xiaomi-pine.dts
@@ -1,0 +1,19 @@
+/dts-v1/;
+
+/include/ "msm8952.dtsi"
+
+/ {
+    compatible = "qcom,sdm439", "xiaomi,pine", "lk2nd,device";
+    model = "Xiaomi Redmi 7A";
+    qcom,msm-id = <353 0x00>;
+    qcom,board-id = <0xb 2>;
+
+    // Bootloader won't continue if it can't delete some nodes from below
+    soc {
+        #address-cells = <1>;
+        #size-cells = <1>;
+        ranges = <0x0 0x0 0x0 0xffffffff>;
+    };
+
+    __symbols__ {};
+};


### PR DESCRIPTION
To work, you need to flash the custom dtbo.img to DTBO partition.
(https://github.com/hitechshell/sdm439-empty-dtbo)