### PR TITLE
dts: xiaomi-{markw,mido,vince}: use touchscreen-compatible

### DIFF
--- a/dts/msm8953-xiaomi-common.dts
+++ b/dts/msm8953-xiaomi-common.dts
@@ -65,22 +65,32 @@
 
 			qcom,mdss_dsi_ili9885_boe_fhd_video {
 				compatible = "xiaomi,boe-ili9885";
+				touchscreen-compatible = "edt,edt-ft5406";
+				// touchscreen-compatible = "goodix,gt917d";
 			};
 
 			qcom,mdss_dsi_nt35532_fhd_video {
 				compatible = "xiaomi,nt35532";
+				touchscreen-compatible = "edt,edt-ft5406";
+				// touchscreen-compatible = "goodix,gt917d";
 			};
 
 			qcom,mdss_dsi_nt35596_tianma_fhd_video {
 				compatible = "xiaomi,tianma-nt35596";
+				touchscreen-compatible = "edt,edt-ft5406";
+				// touchscreen-compatible = "goodix,gt917d";
 			};
 
 			qcom,mdss_dsi_otm1911_fhd_video {
 				compatible = "xiaomi,otm1911";
+				touchscreen-compatible = "edt,edt-ft5406";
+				// touchscreen-compatible = "goodix,gt917d";
 			};
 
 			qcom,mdss_dsi_r63350_ebbg_fhd_video {
 				compatible = "xiaomi,ebbg-r63350";
+				touchscreen-compatible = "edt,edt-ft5406";
+				// touchscreen-compatible = "goodix,gt917d";
 			};
 		};
 	};

--- a/dts/msm8953-xiaomi-markw.dts
+++ b/dts/msm8953-xiaomi-markw.dts
@@ -18,9 +18,13 @@
 
 		qcom,mdss_dsi_nt35596_ebbg_1080p_video {
 			compatible = "mdss,nt35596-ebbg";
+			touchscreen-compatible = "edt,edt-ft5336";
+			// touchscreen-compatible = "atmel,maxtouch";
 		};
 		qcom,mdss_dsi_r63350_1080p_video {
 			compatible = "mdss,r63350";
+			touchscreen-compatible = "edt,edt-ft5336";
+			// touchscreen-compatible = "atmel,maxtouch";
 		};
 	};
 };

--- a/dts/msm8953-xiaomi-vince.dts
+++ b/dts/msm8953-xiaomi-vince.dts
@@ -17,18 +17,28 @@
 		compatible = "xiaomi,vince-panel";
 		qcom,mdss_dsi_td4310_fhdplus_video_e7 {
 			compatible = "xiaomi,td4310-fhdplus-e7";
+			touchscreen-compatible = "syna,rmi4-i2c";
+			// touchscreen-compatible = "novatek,nt36525-i2c";
 		};
 		qcom,mdss_dsi_td4310_fhdplus_video_e7_g55 {
 			compatible = "xiaomi,td4310-fhdplus-e7-g55";
+			touchscreen-compatible = "syna,rmi4-i2c";
+			// touchscreen-compatible = "novatek,nt36525-i2c";
 		};
 		qcom,mdss_dsi_td4310_ebbg_fhdplus_video_e7 {
 			compatible = "xiaomi,td4310-ebbg-fhdplus-e7";
+			touchscreen-compatible = "syna,rmi4-i2c";
+			// touchscreen-compatible = "novatek,nt36525-i2c";
 		};
 		qcom,mdss_dsi_nt36672_tianma_fhdplus_video_e7 {
 			compatible = "xiaomi,nt36672-tianma-fhdplus-e7";
+			touchscreen-compatible = "syna,rmi4-i2c";
+			// touchscreen-compatible = "novatek,nt36525-i2c";
 		};
 		qcom,mdss_dsi_nt36672_csot_fhdplus_video_e7 {
 			compatible = "xiaomi,nt36672-csot-fhdplus-e7";
+			touchscreen-compatible = "syna,rmi4-i2c";
+			// touchscreen-compatible = "novatek,nt36525-i2c";
 		};
 	};
 };


### PR DESCRIPTION
Use touchscreen_compatible for allow override touchscreen.

edt-ft5406 enabled for all device by default because there are same panels with different touch.

Related kernel PR: https://github.com/msm8953-mainline/linux/pull/163