### PR TITLE
platform: msm_shared: Check for null pointer in hw_platform

### DIFF
--- a/platform/msm_shared/smem.c
+++ b/platform/msm_shared/smem.c
@@ -269,7 +269,7 @@ size_t smem_get_hw_platform_name(void *buf, uint32_t buf_size)
 	}
 
 	hw_id = board_hardware_id();
-	if (hw_id >= ARRAY_SIZE(hw_platform))
+	if (hw_id >= ARRAY_SIZE(hw_platform) || hw_platform[hw_id] == '\0')
 		hw_id = HW_PLATFORM_UNKNOWN;
 
 	if (buf_size < strlen(hw_platform[hw_id]) + 1)


### PR DESCRIPTION
Prevents lk2nd from crashing if hw_platform is not out of bounds for the array but undefined.

Original CLO commit https://git.codelinaro.org/clo/la/kernel/lk/-/commit/7b1b74235adfb981ece4f5a7d1a8f8edfa65c8e1

Fixes: 511e22a95c95038216bb94052bedddf6587d9eea ("smem: Default to unknown platform if hardware id is out of range")