### PR TITLE
Add support for 10or G (G)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ and then loaded by lk2nd.
 - SDM632
 
 ### Supported devices
+- 10or G (G)
 - Motorola Moto G4 Play (harpia)
 - Motorola Moto G5 Plus (potter)
 - Samsung Galaxy A3 (2015) - SM-A300FU

--- a/dts/msm8953-10or-G.dts
+++ b/dts/msm8953-10or-G.dts
@@ -10,24 +10,26 @@
 	qcom,board-id= <0x2000b 0x0>;
 	qcom,pmic-id = <0x10016 0x10011 0x00 0x00>;
 
-	model = "10Or G";
-	compatible = "tenor,g", "qcom,msm8953", "lk2nd,device";
-	lk2nd,pstore = <0x9ff00000 0x100000>;
+	model = "10or G";
+	compatible = "10or,G", "qcom,msm8953", "lk2nd,device";
+	lk2nd,pstore = <0x9ff00000 0x300000>;
 	
 	panel {
-		
-			compatible = "tenor,g-panel";
+			compatible = "10or,G-panel";
 
 			qcom,mdss_dsi_hx8399c_auo_53_1080p_video {
-				compatible = "tenor,hx8399c_auo";
+				compatible = "10or,hx8399c_auo";
+				touchscreen-compatible = "edt,edt-ft5406";
 			};
 
 			qcom,mdss_dsi_ili7807d_djn_53_1080p_video {
-				compatible = "tenor,ili7807d_djn";
+				compatible = "10or,ili7807d_djn";
+				touchscreen-compatible = "goodix,gt917d";
 			};
 
 			qcom,mdss_dsi_ili7807d_djn_auo_53_1080p_video {
-				compatible = "tenor,ili7807d_djn_auo";
+				compatible = "10or,ili7807d_djn_auo";
+				touchscreen-compatible = "goodix,gt917d";
 			};
 
 		};

--- a/dts/msm8953-10or-g.dts
+++ b/dts/msm8953-10or-g.dts
@@ -11,25 +11,25 @@
 	qcom,pmic-id = <0x10016 0x10011 0x00 0x00>;
 
 	model = "10or G";
-	compatible = "10or,G", "qcom,msm8953", "lk2nd,device";
-	lk2nd,pstore = <0x9ff00000 0x300000>;
+	compatible = "10or,g", "qcom,msm8953", "lk2nd,device";
+	lk2nd,pstore = <0x9ff00000 0x100000>;
 	
 	panel {
-			compatible = "10or,G-panel";
+			compatible = "10or,g-panel";
 
 			qcom,mdss_dsi_hx8399c_auo_53_1080p_video {
-				compatible = "10or,hx8399c_auo";
-				touchscreen-compatible = "edt,edt-ft5406";
+				compatible = "10or,g-hx8399c-auo";
+				// touchscreen-compatible = "edt,edt-ft5406";
 			};
 
 			qcom,mdss_dsi_ili7807d_djn_53_1080p_video {
-				compatible = "10or,ili7807d_djn";
-				touchscreen-compatible = "goodix,gt917d";
+				compatible = "10or,g-ili7807d-djn";
+				// touchscreen-compatible = "goodix,gt917d";
 			};
 
 			qcom,mdss_dsi_ili7807d_djn_auo_53_1080p_video {
-				compatible = "10or,ili7807d_djn_auo";
-				touchscreen-compatible = "goodix,gt917d";
+				compatible = "10or,g-ili7807d-djn-auo";
+				// touchscreen-compatible = "goodix,gt917d";
 			};
 
 		};

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -7,7 +7,7 @@ DTBS += \
 endif
 ifeq ($(PROJECT), msm8953-secondary)
 DTBS += \
-	$(LOCAL_DIR)/msm8953-10or-G.dtb \
+	$(LOCAL_DIR)/msm8953-10or-g.dtb \
 	$(LOCAL_DIR)/msm8953-huawei-milan.dtb \
 	$(LOCAL_DIR)/msm8953-lenovo-kuntao.dtb \
 	$(LOCAL_DIR)/msm8953-meizu-m1721.dtb \

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -7,11 +7,11 @@ DTBS += \
 endif
 ifeq ($(PROJECT), msm8953-secondary)
 DTBS += \
+	$(LOCAL_DIR)/msm8953-10or-G.dtb \
 	$(LOCAL_DIR)/msm8953-huawei-milan.dtb \
 	$(LOCAL_DIR)/msm8953-lenovo-kuntao.dtb \
 	$(LOCAL_DIR)/msm8953-meizu-m1721.dtb \
 	$(LOCAL_DIR)/msm8953-motorola-potter.dtb \
-	$(LOCAL_DIR)/msm8953-tenor-holland.dtb \
 	$(LOCAL_DIR)/msm8953-xiaomi-common.dtb \
 	$(LOCAL_DIR)/msm8953-xiaomi-daisy.dtb \
 	$(LOCAL_DIR)/msm8953-xiaomi-markw.dtb \


### PR DESCRIPTION
Adhere to the officially rebranded name.

Adjust memory allocation for the pstore logs.

Use the touchscreen-compatible support to associate the Goodix GT917D touchscreen with panels Ilitek ili7807 and Focaltech ft5406 with panel Himax hx8399c.