### PR TITLE
Add Motorola Moto G6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,3 +9,10 @@ jobs:
       platform: msm8953-secondary
       artifacts: |
         build-*/lk2nd.img
+  lk2nd-motorola-ali:
+    name: lk2nd
+    uses: ./.github/workflows/lk2nd.yml
+    with:
+      platform: motorola-ali-secondary
+      artifacts: |
+        build-*/lk2nd.img

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ and then loaded by lk2nd.
 ### Supported devices
 - Motorola Moto G4 Play (harpia)
 - Motorola Moto G5 Plus (potter)
+- Motorola Moto G6 (ali) NOTE: Build with motorola-ali-secondary
 - Samsung Galaxy A3 (2015) - SM-A300FU
 - Samsung Galaxy A5 (2015) - SM-A500FU
 - Samsung Galaxy J5 (2016) - SM-J510FN

--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -5,6 +5,10 @@ DTBS += \
 	$(LOCAL_DIR)/msm8916-longcheer-l8150.dtb \
 	$(LOCAL_DIR)/msm8916-samsung.dtb
 endif
+ifeq ($(PROJECT), motorola-ali-secondary)
+DTBS += \
+	$(LOCAL_DIR)/sdm450-motorola-ali.dtb
+endif
 ifeq ($(PROJECT), msm8953-secondary)
 DTBS += \
 	$(LOCAL_DIR)/msm8953-huawei-milan.dtb \

--- a/dts/sdm450-motorola-ali.dts
+++ b/dts/sdm450-motorola-ali.dts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+/include/ "msm8953.dtsi"
+
+/ {
+	model = "Motorola Moto G6 (ali)";
+	compatible = "motorola,ali", "qcom,sdm450", "lk2nd,device";
+	qcom,msm-id = <0x152 0x00>;
+	qcom,board-id = <0x41 0xb1a0>,
+		<0x42 0xb1a0>,
+		<0x42 0xb1b0>,
+		<0x42 0xb200>,
+		<0x43 0xb200>,
+		<0x43 0xc100>,
+		<0x43 0xc200>,
+		<0x44 0xc200>;
+	lk2nd,pstore = <0xef000000 0xC0000>;
+
+	panel {
+		compatible = "motorola,ali-panel";
+
+		qcom,mdss_dsi_mot_auo_565_1080p_vid_v0 {
+			compatible = "motorola,ali-panel-auo";
+		};
+
+		qcom,mdss_dsi_mot_boe_565_1080p_vid_v0 {
+			compatible = "motorola,ali-panel-boe";
+		};
+
+		qcom,mdss_dsi_mot_tianma_565_1080p_vid_v0 {
+			compatible = "motorola,ali-panel-tianma";
+		};
+	};
+};

--- a/project/motorola-ali-secondary.mk
+++ b/project/motorola-ali-secondary.mk
@@ -1,0 +1,2 @@
+LOCAL_DIR := $(GET_LOCAL_DIR)
+include $(LOCAL_DIR)/msm8953-secondary.mk


### PR DESCRIPTION
Add Motorola Moto G6, it needs a separated project because otherwise the device bootloader will crash.