### PR TITLE
Add Lenovo Smart Tab M10 (wifi variant) lk2nd DTS

### DIFF
--- a/dts/rules.mk
+++ b/dts/rules.mk
@@ -22,6 +22,7 @@ DTBS += \
 	$(LOCAL_DIR)/msm8953-xiaomi-vince.dtb \
 	$(LOCAL_DIR)/msm8953-xiaomi-ysl.dtb \
 	$(LOCAL_DIR)/sdm450-htc-brepdugl.dtb \
+	$(LOCAL_DIR)/sdm450-lenovo-tbx605f.dtb \
 	$(LOCAL_DIR)/sdm450-samsung-r04.dtb \
 	$(LOCAL_DIR)/sdm450-samsung-r05.dtb \
 	$(LOCAL_DIR)/sdm450-xiaomi-rosy.dtb \

--- a/dts/sdm450-lenovo-tbx605f.dts
+++ b/dts/sdm450-lenovo-tbx605f.dts
@@ -1,0 +1,12 @@
+/dts-v1/;
+
+/include/ "msm8953.dtsi"
+
+/ {
+	qcom,msm-id = <0x15f 0x00>;
+	qcom,board-id = <0x08 0x00>;
+	qcom,pmic-id = <0x10016 0x10011 0x00 0x00>;
+
+	model = "Lenovo Smart Tab M10 (tbx605f)";
+	compatible = "lenovo,tbx605f", "qcom,sdm450", "lk2nd,device";
+};


### PR DESCRIPTION
This will allow booting mainline DT submitted at https://lore.kernel.org/all/20240523-topic-sdm450-upstream-tbx605f-v1-0-e52b89133226@linaro.org/